### PR TITLE
Fix Windows plugin compilation

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -10,4 +10,4 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 )
 target_compile_definitions(${PROJECT_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
 target_include_directories(${PROJECT_NAME} INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
-target_link_libraries(${PROJECT_NAME} PRIVATE flutter flutter_wrapper_plugin)
+target_link_libraries(${PROJECT_NAME} PRIVATE flutter flutter_wrapper_plugin WindowsApp)

--- a/windows/universal_ble_server_plugin.cpp
+++ b/windows/universal_ble_server_plugin.cpp
@@ -1,9 +1,13 @@
 #include "universal_ble_server_plugin.h"
 
-#include <windows.devices.bluetooth.genericattributeprofile.h>
 #include <flutter/event_channel.h>
 #include <flutter/standard_method_codec.h>
+#include <map>
+#include <winrt/Windows.Devices.Bluetooth.h>
+#include <winrt/Windows.Devices.Bluetooth.GenericAttributeProfile.h>
+#include <winrt/Windows.Foundation.h>
 
+using namespace winrt;
 using namespace winrt::Windows::Devices::Bluetooth::GenericAttributeProfile;
 using namespace flutter;
 


### PR DESCRIPTION
## Summary
- include required WinRT headers and utilities in Windows plugin
- link WindowsApp library for Windows builds

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e718fe988325bc11d8e7fc87b6ca