### PR TITLE
feat(android): implement basic BLE server plugin

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 33
+    namespace "com.example.universal_ble_server"
 
     defaultConfig {
         minSdkVersion 21

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,4 +4,6 @@
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
 </manifest>

--- a/android/src/main/kotlin/com/example/universal_ble_server/UniversalBleServerPlugin.kt
+++ b/android/src/main/kotlin/com/example/universal_ble_server/UniversalBleServerPlugin.kt
@@ -1,28 +1,43 @@
 package com.example.universal_ble_server
 
-import android.bluetooth.*
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattServer
+import android.bluetooth.BluetoothGattServerCallback
+import android.bluetooth.BluetoothGattService
+import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothProfile
+import android.bluetooth.le.AdvertiseCallback
+import android.bluetooth.le.AdvertiseData
+import android.bluetooth.le.AdvertiseSettings
+import android.bluetooth.le.BluetoothLeAdvertiser
 import android.content.Context
-import androidx.annotation.NonNull
+import android.os.ParcelUuid
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
+import java.util.UUID
+import java.util.concurrent.CopyOnWriteArraySet
 
-/**
- * Android implementation of the Universal BLE Server plugin.
- */
+/** Android implementation of the UniversalBleServer plugin. */
 class UniversalBleServerPlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
   private lateinit var channel: MethodChannel
   private lateinit var writeChannel: EventChannel
   private lateinit var readChannel: EventChannel
-  private var context: Context? = null
-  private var gattServer: BluetoothGattServer? = null
-  private val characteristics = mutableMapOf<String, BluetoothGattCharacteristic>()
-  private var connectedDevice: BluetoothDevice? = null
   private var writeSink: EventChannel.EventSink? = null
   private var readSink: EventChannel.EventSink? = null
 
-  override fun onAttachedToEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
+  private var context: Context? = null
+  private var bluetoothManager: BluetoothManager? = null
+  private var gattServer: BluetoothGattServer? = null
+  private var advertiser: BluetoothLeAdvertiser? = null
+  private val devices = CopyOnWriteArraySet<BluetoothDevice>()
+  private val characteristics = HashMap<String, BluetoothGattCharacteristic>()
+
+  override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
     context = binding.applicationContext
     channel = MethodChannel(binding.binaryMessenger, "universal_ble_server/methods")
     channel.setMethodCallHandler(this)
@@ -48,17 +63,28 @@ class UniversalBleServerPlugin : FlutterPlugin, MethodChannel.MethodCallHandler 
         readSink = null
       }
     })
+
+    bluetoothManager = context?.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+    advertiser = bluetoothManager?.adapter?.bluetoothLeAdvertiser
   }
 
-  override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
+  override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+    stopServer()
     channel.setMethodCallHandler(null)
+    writeChannel.setStreamHandler(null)
+    readChannel.setStreamHandler(null)
+    context = null
   }
 
   override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
     when (call.method) {
       "startServer" -> {
-        val serviceUuid = call.argument<String>("serviceUuid")!!
-        val chars = call.argument<List<Map<String, Any>>>("characteristics") ?: emptyList()
+        val args = call.arguments as? Map<*, *> ?: run {
+          result.error("bad_args", null, null)
+          return
+        }
+        val serviceUuid = args["serviceUuid"] as? String ?: return
+        val chars = (args["characteristics"] as? List<*>)?.mapNotNull { it as? Map<*, *> } ?: emptyList()
         startServer(serviceUuid, chars)
         result.success(null)
       }
@@ -67,8 +93,13 @@ class UniversalBleServerPlugin : FlutterPlugin, MethodChannel.MethodCallHandler 
         result.success(null)
       }
       "notify" -> {
-        val uuid = call.argument<String>("characteristicUuid")!!
-        val value = call.argument<ByteArray>("value")!!
+        val args = call.arguments as? Map<*, *> ?: run {
+          result.error("bad_args", null, null)
+          return
+        }
+        val uuid = args["characteristicUuid"] as? String ?: return
+        val valueList = args["value"] as? List<*>
+        val value = valueList?.map { (it as Int).toByte() }?.toByteArray() ?: byteArrayOf()
         notify(uuid, value)
         result.success(null)
       }
@@ -76,67 +107,73 @@ class UniversalBleServerPlugin : FlutterPlugin, MethodChannel.MethodCallHandler 
     }
   }
 
-  private fun startServer(serviceUuid: String, characteristicMaps: List<Map<String, Any>>) {
-    val bluetoothManager = context!!.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
-    gattServer = bluetoothManager.openGattServer(context, gattCallback)
-    val service = BluetoothGattService(java.util.UUID.fromString(serviceUuid), BluetoothGattService.SERVICE_TYPE_PRIMARY)
-    for (map in characteristicMaps) {
-      val uuid = java.util.UUID.fromString(map["uuid"] as String)
-      val propsList = map["properties"] as List<*>
-      var props = 0
-      var perms = 0
-      if (propsList.contains("read")) {
-        props = props or BluetoothGattCharacteristic.PROPERTY_READ
-        perms = perms or BluetoothGattCharacteristic.PERMISSION_READ
+  private fun startServer(serviceUuid: String, chars: List<Map<*, *>>) {
+    val adapter = bluetoothManager?.adapter ?: return
+    gattServer = bluetoothManager?.openGattServer(context, gattCallback)
+    val service = BluetoothGattService(UUID.fromString(serviceUuid), BluetoothGattService.SERVICE_TYPE_PRIMARY)
+    for (c in chars) {
+      val uuid = c["uuid"] as? String ?: continue
+      val props = c["properties"] as? List<*> ?: continue
+      var properties = 0
+      var permissions = 0
+      if (props.contains("read")) {
+        properties = properties or BluetoothGattCharacteristic.PROPERTY_READ
+        permissions = permissions or BluetoothGattCharacteristic.PERMISSION_READ
       }
-      if (propsList.contains("write")) {
-        props = props or BluetoothGattCharacteristic.PROPERTY_WRITE
-        perms = perms or BluetoothGattCharacteristic.PERMISSION_WRITE
+      if (props.contains("write")) {
+        properties = properties or BluetoothGattCharacteristic.PROPERTY_WRITE
+        permissions = permissions or BluetoothGattCharacteristic.PERMISSION_WRITE
       }
-      if (propsList.contains("notify")) {
-        props = props or BluetoothGattCharacteristic.PROPERTY_NOTIFY
+      if (props.contains("notify")) {
+        properties = properties or BluetoothGattCharacteristic.PROPERTY_NOTIFY
       }
-      val characteristic = BluetoothGattCharacteristic(uuid, props, perms)
-      val value = map["value"] as? ByteArray
-      if (value != null) characteristic.value = value
+      val characteristic = BluetoothGattCharacteristic(UUID.fromString(uuid), properties, permissions)
+      val value = c["value"] as? List<*>
+      if (value != null) {
+        characteristic.value = value.map { (it as Int).toByte() }.toByteArray()
+      }
+      characteristics[uuid] = characteristic
       service.addCharacteristic(characteristic)
-      characteristics[uuid.toString()] = characteristic
     }
     gattServer?.addService(service)
+    advertiser?.startAdvertising(
+      AdvertiseSettings.Builder().setConnectable(true).setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY).build(),
+      AdvertiseData.Builder().addServiceUuid(ParcelUuid(UUID.fromString(serviceUuid))).build(),
+      AdvertiseData.Builder().build(),
+      advertiseCallback
+    )
   }
 
   private fun stopServer() {
+    advertiser?.stopAdvertising(advertiseCallback)
     gattServer?.close()
     gattServer = null
+    devices.clear()
     characteristics.clear()
-    connectedDevice = null
   }
 
   private fun notify(uuid: String, value: ByteArray) {
     val characteristic = characteristics[uuid] ?: return
     characteristic.value = value
-    connectedDevice?.let {
-      gattServer?.notifyCharacteristicChanged(it, characteristic, false)
+    devices.forEach { device ->
+      gattServer?.notifyCharacteristicChanged(device, characteristic, false)
     }
   }
+
+  private val advertiseCallback = object : AdvertiseCallback() {}
 
   private val gattCallback = object : BluetoothGattServerCallback() {
     override fun onConnectionStateChange(device: BluetoothDevice, status: Int, newState: Int) {
       if (newState == BluetoothProfile.STATE_CONNECTED) {
-        connectedDevice = device
+        devices.add(device)
       } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
-        connectedDevice = null
+        devices.remove(device)
       }
     }
 
-    override fun onCharacteristicReadRequest(
-      device: BluetoothDevice,
-      requestId: Int,
-      offset: Int,
-      characteristic: BluetoothGattCharacteristic
-    ) {
-      readSink?.success(mapOf("characteristicUuid" to characteristic.uuid.toString()))
+    override fun onCharacteristicReadRequest(device: BluetoothDevice, requestId: Int, offset: Int, characteristic: BluetoothGattCharacteristic) {
       gattServer?.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, characteristic.value)
+      readSink?.success(mapOf("characteristicUuid" to characteristic.uuid.toString()))
     }
 
     override fun onCharacteristicWriteRequest(
@@ -149,8 +186,16 @@ class UniversalBleServerPlugin : FlutterPlugin, MethodChannel.MethodCallHandler 
       value: ByteArray
     ) {
       characteristic.value = value
-      writeSink?.success(mapOf("characteristicUuid" to characteristic.uuid.toString(), "value" to value))
-      gattServer?.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, null)
+      if (responseNeeded) {
+        gattServer?.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, null)
+      }
+      writeSink?.success(
+        mapOf(
+          "characteristicUuid" to characteristic.uuid.toString(),
+          "value" to value.toList()
+        )
+      )
     }
   }
 }
+


### PR DESCRIPTION
## Summary
- implement Android GATT server with advertising and read/write streams
- expose BLE permissions in Android manifest and namespace build setup

## Testing
- `dart format --output=none --set-exit-if-changed .` *(fails: dart not installed)*
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f164a1bc8325b4c3b8b35adc9d1a