### PR TITLE
Fix Windows plugin header path

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -2,12 +2,11 @@ cmake_minimum_required(VERSION 3.14)
 set(PROJECT_NAME "universal_ble_server_plugin")
 add_library(${PROJECT_NAME} SHARED
   "universal_ble_server_plugin.cpp"
-  "universal_ble_server_plugin.h"
 )
 set_target_properties(${PROJECT_NAME} PROPERTIES
   WIN32_EXECUTABLE FALSE
   OUTPUT_NAME "universal_ble_server_plugin"
 )
 target_compile_definitions(${PROJECT_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
-target_include_directories(${PROJECT_NAME} INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
+target_include_directories(${PROJECT_NAME} INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(${PROJECT_NAME} PRIVATE flutter flutter_wrapper_plugin WindowsApp)

--- a/windows/include/universal_ble_server/universal_ble_server_plugin.h
+++ b/windows/include/universal_ble_server/universal_ble_server_plugin.h
@@ -25,4 +25,18 @@ class UniversalBleServerPlugin : public flutter::Plugin {
 
 }  // namespace universal_ble_server
 
+#if defined(_WIN32)
+#ifdef FLUTTER_PLUGIN_IMPL
+#define UNIVERSAL_BLE_SERVER_PLUGIN_EXPORT __declspec(dllexport)
+#else
+#define UNIVERSAL_BLE_SERVER_PLUGIN_EXPORT __declspec(dllimport)
+#endif
+#else
+#define UNIVERSAL_BLE_SERVER_PLUGIN_EXPORT
+#endif
+
+extern "C" UNIVERSAL_BLE_SERVER_PLUGIN_EXPORT void
+UniversalBleServerPluginRegisterWithRegistrar(
+    flutter::PluginRegistrarWindows* registrar);
+
 #endif  // FLUTTER_PLUGIN_UNIVERSAL_BLE_SERVER_PLUGIN_H_

--- a/windows/universal_ble_server_plugin.cpp
+++ b/windows/universal_ble_server_plugin.cpp
@@ -1,4 +1,4 @@
-#include "universal_ble_server_plugin.h"
+#include "include/universal_ble_server/universal_ble_server_plugin.h"
 
 #include <flutter/event_channel.h>
 #include <flutter/standard_method_codec.h>
@@ -126,3 +126,9 @@ void UniversalBleServerPlugin::HandleMethodCall(
 }
 
 }  // namespace universal_ble_server
+
+extern "C" void UniversalBleServerPluginRegisterWithRegistrar(
+    flutter::PluginRegistrarWindows* registrar) {
+  universal_ble_server::UniversalBleServerPlugin::RegisterWithRegistrar(
+      registrar);
+}


### PR DESCRIPTION
## Summary
- move Windows plugin header into package include directory
- update CMake to expose include path and adjust source include
- export C wrapper for plugin registrar so generated registrant can link

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f1b7c65c8325a2ee29eb602ee5fa